### PR TITLE
override check name 📇

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,15 @@ Defaults to `True` (disable with `--filter_annotations=false`).
 
 When set to `True`, annotations are added only when they apply to a line modified in the pull request (or a line immediately around it based on the git patch). When set to `False`, all annotations are added regardless of file or line.
 
-### `--annotate_beginning`
+#### `--annotate_beginning`
 Defaults to `True` (disable with `--annotate_beginning=false`).
 
 When set to `True`, annotations are submitted for the start line of a finding only (rather than the full range of lines in the finding). With this set to `False`, GitHub's default of displaying annotations on the end line of a finding is used.
+
+#### `--check_name`
+Defaults to the tool driver name from the submitted sarif (override with `--check_name "Override name of check"`).
+
+When set to any string, the GitHub check is named that string (rather than the name of the tool which reported the results). Use this configuration in the event that the same tool powers multiple checks on your PR.
 
 ## Development
 

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func main() {
 	appKeyPath := flag.String("key_path", "", "absolute path to your GitHub app's private key")
 
 	sarifPath := flag.String("sarif_path", "", "absolute path to your sarif file")
+	checkNameOverride := flag.String("check_name", "", "name of the check, defaults to tool name from sarif")
 
 	filterAnnotations := flag.Bool("filter_annotations", true, "filter annotations by lines found in the git patches, default true")
 	annotateStartLineOnly := flag.Bool("annotate_beginning", true, "force annotations to start line of a finding (if set to false, GitHub default of end is used), default true")
@@ -90,7 +91,12 @@ func main() {
 		annotations = append(annotations, annotation)
 	}
 
-	if err := annotator.PostAnnotations(annotations, tool.Name, *filterAnnotations, *annotateStartLineOnly); err != nil {
+	checkName := tool.Name
+	if *checkNameOverride != "" {
+		checkName = *checkNameOverride
+	}
+
+	if err := annotator.PostAnnotations(annotations, checkName, *filterAnnotations, *annotateStartLineOnly); err != nil {
 		log.Fatal(errors.Wrap(err, "failed to post annotations"))
 	}
 }


### PR DESCRIPTION
Add a flag to allow users to modify the name assigned to the check.
