### PR TITLE
deduplicate sarif results 🚫👯

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Annotations are added to the pull request file page marking the line(s) impacted
 
 ![A Python code snippet which uses the method `print`. The line of code is annotated with a warning from Semgrep.](docs/img/semgrep/annotation-no_print.png)
 
+If a finding is reported multiple times in the input sarif (same file, lines, finding id, and level), `less-advanced-security` will deduplicate these and post only one annotation.
+
 ### Commit (and PR) status checks
 
 A check is added to the commit (and pull request) denoting the status of the most severe annotation. Failures result in a failing check, warnings result in a pending check, notices result in a passing check.

--- a/converter.go
+++ b/converter.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"less-advanced-security/github"
+	"less-advanced-security/sarif"
+
+	"github.com/pkg/errors"
+)
+
+func resultToAnnotation(result sarif.Result) (*github.Annotation, error) {
+	if len(result.Locations) != 1 {
+		return nil, errors.Errorf("each result must have 1 location, not %d", len(result.Locations))
+	}
+	if result.Locations[0].StartLine == nil {
+		return nil, errors.Errorf("each result must have a start line")
+	}
+	startLine := *result.Locations[0].StartLine
+
+	endLine := startLine
+	if result.Locations[0].EndLine != nil {
+		endLine = *result.Locations[0].EndLine
+	}
+
+	title := result.RuleID
+
+	return github.CreateAnnotation(result.Locations[0].Filepath, startLine, endLine, result.Level, title, result.Message, result.Raw)
+}

--- a/converter.go
+++ b/converter.go
@@ -7,6 +7,38 @@ import (
 	"github.com/pkg/errors"
 )
 
+type AnnotationCount struct {
+	annotation *github.Annotation
+	count      int
+}
+
+func resultsToAnnotations(results []*sarif.Result) ([]*github.Annotation, error) {
+	annotationHashToCount := make(map[[16]byte]*AnnotationCount)
+	for _, result := range results {
+		if result == nil {
+			continue
+		}
+		annotation, err := resultToAnnotation(*result)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to normalize result")
+		}
+
+		annotationHash := annotation.Hash()
+		if annotationHashToCount[annotationHash] != nil {
+			annotationHashToCount[annotationHash].count += 1
+		} else {
+			annotationHashToCount[annotationHash] = &AnnotationCount{annotation: annotation, count: 1}
+		}
+	}
+	annotations := []*github.Annotation{}
+	for _, annotationCount := range annotationHashToCount {
+		annotationCount.annotation.MaybeAppendReportCount(annotationCount.count)
+		annotations = append(annotations, annotationCount.annotation)
+	}
+
+	return annotations, nil
+}
+
 func resultToAnnotation(result sarif.Result) (*github.Annotation, error) {
 	if len(result.Locations) != 1 {
 		return nil, errors.Errorf("each result must have 1 location, not %d", len(result.Locations))

--- a/converter_test.go
+++ b/converter_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"less-advanced-security/github"
+	"less-advanced-security/sarif"
+)
+
+func TestSarifToAnnotationConverter(t *testing.T) {
+	five, ten := 5, 10
+
+	sarifWithStartLine := sarif.Result{
+		Message: "this is a failure",
+		RuleID:  "fail-1-2-3",
+		Raw:     "raw failure text",
+		Level:   "error",
+		Locations: []sarif.ResultLocation{
+			sarif.ResultLocation{Filepath: "test/file", StartLine: &five}},
+	}
+	// accuracy of annotation creation tested elsewhere
+	annotationWithStartLine, _ := github.CreateAnnotation("test/file", five, five, "error", "fail-1-2-3", "this is a failure", "raw failure text")
+
+	sarifWithStartAndEndLine := sarif.Result{
+		Message: "this is a failure",
+		RuleID:  "fail-1-2-3",
+		Raw:     "raw failure text",
+		Level:   "error",
+		Locations: []sarif.ResultLocation{
+			sarif.ResultLocation{Filepath: "test/file", StartLine: &five, EndLine: &ten}},
+	}
+	// accuracy of annotation creation tested elsewhere
+	annotationWithStartAndEndLine, _ := github.CreateAnnotation("test/file", five, ten, "error", "fail-1-2-3", "this is a failure", "raw failure text")
+
+	tests := []struct {
+		name       string
+		result     sarif.Result
+		annotation *github.Annotation
+		errMessage string
+	}{
+		{
+			"no locations",
+			sarif.Result{Locations: []sarif.ResultLocation{}},
+			&github.Annotation{},
+			"each result must have 1 location, not 0",
+		},
+		{
+			"two locations",
+			sarif.Result{Locations: []sarif.ResultLocation{sarif.ResultLocation{}, sarif.ResultLocation{}}},
+			&github.Annotation{},
+			"each result must have 1 location, not 2",
+		},
+		{
+			"no start line",
+			sarif.Result{Locations: []sarif.ResultLocation{sarif.ResultLocation{Filepath: "test/file"}}},
+			&github.Annotation{},
+			"each result must have a start line",
+		},
+		{
+			"start line only",
+			sarifWithStartLine,
+			annotationWithStartLine,
+			"",
+		},
+		{
+			"start and end line",
+			sarifWithStartAndEndLine,
+			annotationWithStartAndEndLine,
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resultToAnnotation(tt.result)
+			if tt.errMessage != "" {
+				if err == nil || err.Error() != tt.errMessage {
+					t.Errorf("Expected error %q but got %q.", tt.errMessage, err)
+				}
+			} else if err != nil {
+				t.Errorf("Got error %q but expected no error.", err)
+			} else if !reflect.DeepEqual(got, tt.annotation) {
+				t.Errorf("Expected annotation %s but got %s.", tt.annotation, got)
+			}
+		})
+	}
+}

--- a/converter_test.go
+++ b/converter_test.go
@@ -147,9 +147,9 @@ func TestSarifsToAnnotationsConverter(t *testing.T) {
 	annotationNewEndLine, _ := github.CreateAnnotation("test/file", five, ten, "error", "new-id-3", "this is a failure", "raw failure text")
 
 	tests := []struct {
-		name        string
-		results     []*sarif.Result
-		annotations []*github.Annotation
+		name                string
+		results             []*sarif.Result
+		expectedAnnotations []*github.Annotation
 	}{
 		{
 			"two results",
@@ -179,11 +179,26 @@ func TestSarifsToAnnotationsConverter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := resultsToAnnotations(tt.results)
+			gotAnnotations, err := resultsToAnnotations(tt.results)
 			if err != nil {
 				t.Errorf("Expected no error but got %q.", err)
-			} else if !reflect.DeepEqual(got, tt.annotations) {
-				t.Errorf("Expected annotations %s but got %q.", tt.annotations, got)
+				t.FailNow()
+			}
+			for _, expectedAnnotation := range tt.expectedAnnotations {
+				found := false
+				for _, gotAnnotation := range gotAnnotations {
+					if reflect.DeepEqual(gotAnnotation, expectedAnnotation) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected annotation %s but did not find it.", expectedAnnotation)
+				}
+			}
+
+			if len(tt.expectedAnnotations) != len(gotAnnotations) {
+				t.Errorf("expected %d annotations but got %d", len(tt.expectedAnnotations), len(gotAnnotations))
 			}
 		})
 	}

--- a/github/annotation.go
+++ b/github/annotation.go
@@ -1,6 +1,8 @@
 package github
 
 import (
+	"fmt"
+
 	"github.com/google/go-github/v47/github"
 	"github.com/pkg/errors"
 )
@@ -16,6 +18,18 @@ type Annotation struct {
 	fileName           string
 	startLine, endLine int
 	level              int
+}
+
+func (a Annotation) String() string {
+	checkRunAnnotationString := "{}"
+	if a.githubAnnotation != nil {
+		checkRunAnnotationString = checkRunAnnotationAsString(a.githubAnnotation)
+	}
+	return fmt.Sprintf("{\"fileName\":%q,\"level\":%d,\"startLine\":%d,\"endLine\":%d,\"githubAnnotation\":%s}", a.fileName, a.level, a.startLine, a.endLine, checkRunAnnotationString)
+}
+
+func checkRunAnnotationAsString(a *github.CheckRunAnnotation) string {
+	return fmt.Sprintf("{\"path\":%s,\"message\":%s,\"title\":%s,\"...\":\"...\"}", *a.Path, *a.Message, *a.Title)
 }
 
 // map sarif levels (https://docs.oasis-open.org/sarif/sarif/v2.0/sarif-v2.0.html#_Ref508894469) to GitHub levels

--- a/github/annotation.go
+++ b/github/annotation.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"crypto/md5"
 	"fmt"
 
 	"github.com/google/go-github/v47/github"
@@ -26,6 +27,21 @@ func (a Annotation) String() string {
 		checkRunAnnotationString = checkRunAnnotationAsString(a.githubAnnotation)
 	}
 	return fmt.Sprintf("{\"fileName\":%q,\"level\":%d,\"startLine\":%d,\"endLine\":%d,\"githubAnnotation\":%s}", a.fileName, a.level, a.startLine, a.endLine, checkRunAnnotationString)
+}
+
+func (a Annotation) Hash() [16]byte {
+	return md5.Sum([]byte(fmt.Sprintf("%d-%d-%s-%s-%d", a.startLine, a.endLine, a.fileName, *a.githubAnnotation.Title, a.level)))
+}
+
+func (a *Annotation) MaybeAppendReportCount(reportCount int) {
+	/*
+	* Call only once per annotation - if this is called multiple times, the report
+	* count will be repeatedly appended.
+	 */
+	if reportCount > 1 {
+		newTitle := fmt.Sprintf("%s (reported %d times)", *a.githubAnnotation.Title, reportCount)
+		a.githubAnnotation.Title = &newTitle
+	}
 }
 
 func checkRunAnnotationAsString(a *github.CheckRunAnnotation) string {

--- a/github/annotation_test.go
+++ b/github/annotation_test.go
@@ -48,10 +48,6 @@ func TestLevelStringToNormalizedLevelErrors(t *testing.T) {
 	}
 }
 
-func (a Annotation) String() string {
-	return fmt.Sprintf("{\"fileName\":%q,\"level\":%d,\"startLine\":%d,\"endLine\":%d,\"githubAnnotation\":\"...\"}", a.fileName, a.level, a.startLine, a.endLine)
-}
-
 func compareAnnotation(t *testing.T, expected, received *Annotation) {
 	t.Helper()
 

--- a/main.go
+++ b/main.go
@@ -15,25 +15,6 @@ var (
 	version = "dev"
 )
 
-func resultToAnnotation(result sarif.Result) (*github.Annotation, error) {
-	if len(result.Locations) != 1 {
-		return nil, errors.Errorf("each result must have 1 location, not %d", len(result.Locations))
-	}
-	if result.Locations[0].StartLine == nil {
-		return nil, errors.Errorf("each result must have a start line")
-	}
-	startLine := *result.Locations[0].StartLine
-
-	endLine := startLine
-	if result.Locations[0].EndLine != nil {
-		endLine = *result.Locations[0].EndLine
-	}
-
-	title := result.RuleID
-
-	return github.CreateAnnotation(result.Locations[0].Filepath, startLine, endLine, result.Level, title, result.Message, result.Raw)
-}
-
 func main() {
 	versionFlag := flag.Bool("version", false, "")
 

--- a/main.go
+++ b/main.go
@@ -60,16 +60,9 @@ func main() {
 		log.Fatal(errors.Wrap(err, "failed during setup"))
 	}
 
-	annotations := []*github.Annotation{}
-	for _, result := range results {
-		if result == nil {
-			continue
-		}
-		annotation, err := resultToAnnotation(*result)
-		if err != nil {
-			log.Fatal(errors.Wrap(err, "failed to normalize result"))
-		}
-		annotations = append(annotations, annotation)
+	annotations, err := resultsToAnnotations(results)
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "failed to convert results to annotations"))
 	}
 
 	checkName := tool.Name


### PR DESCRIPTION
When a sarif result is reported multiple times (with the same file,
lines, level, and id), collapse all the reports into one annotation.