### PR TITLE
remove `details` from annotation 🖍️

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -55,5 +55,5 @@ func resultToAnnotation(result sarif.Result) (*github.Annotation, error) {
 
 	title := result.RuleID
 
-	return github.CreateAnnotation(result.Locations[0].Filepath, startLine, endLine, result.Level, title, result.Message, result.Raw)
+	return github.CreateAnnotation(result.Locations[0].Filepath, startLine, endLine, result.Level, title, result.Message)
 }

--- a/converter_test.go
+++ b/converter_test.go
@@ -20,7 +20,7 @@ func TestSarifToAnnotationConverter(t *testing.T) {
 			sarif.ResultLocation{Filepath: "test/file", StartLine: &five}},
 	}
 	// accuracy of annotation creation tested elsewhere
-	annotationWithStartLine, _ := github.CreateAnnotation("test/file", five, five, "error", "fail-1-2-3", "this is a failure", "raw failure text")
+	annotationWithStartLine, _ := github.CreateAnnotation("test/file", five, five, "error", "fail-1-2-3", "this is a failure")
 
 	sarifWithStartAndEndLine := sarif.Result{
 		Message: "this is a failure",
@@ -31,7 +31,7 @@ func TestSarifToAnnotationConverter(t *testing.T) {
 			sarif.ResultLocation{Filepath: "test/file", StartLine: &five, EndLine: &ten}},
 	}
 	// accuracy of annotation creation tested elsewhere
-	annotationWithStartAndEndLine, _ := github.CreateAnnotation("test/file", five, ten, "error", "fail-1-2-3", "this is a failure", "raw failure text")
+	annotationWithStartAndEndLine, _ := github.CreateAnnotation("test/file", five, ten, "error", "fail-1-2-3", "this is a failure")
 
 	tests := []struct {
 		name       string
@@ -100,8 +100,8 @@ func TestSarifsToAnnotationsConverter(t *testing.T) {
 			sarif.ResultLocation{Filepath: "test/file", StartLine: &five}},
 	}
 	// accuracy of annotation creation tested elsewhere
-	annotationOriginal, _ := github.CreateAnnotation("test/file", five, five, "error", "fail-1-2-3", "this is a failure", "raw failure text")
-	annotationOriginalReportedTwice, _ := github.CreateAnnotation("test/file", five, five, "error", "fail-1-2-3 (reported 2 times)", "this is a failure", "raw failure text")
+	annotationOriginal, _ := github.CreateAnnotation("test/file", five, five, "error", "fail-1-2-3", "this is a failure")
+	annotationOriginalReportedTwice, _ := github.CreateAnnotation("test/file", five, five, "error", "fail-1-2-3 (reported 2 times)", "this is a failure")
 
 	sarifAsWarning := sarif.Result{
 		Message: "this is a failure",
@@ -112,8 +112,8 @@ func TestSarifsToAnnotationsConverter(t *testing.T) {
 			sarif.ResultLocation{Filepath: "test/file", StartLine: &five}},
 	}
 	// accuracy of annotation creation tested elsewhere
-	annotationAsWarning, _ := github.CreateAnnotation("test/file", five, five, "warning", "fail-1-2-3", "this is a failure", "raw failure text")
-	annotationAsWarningReportedTwice, _ := github.CreateAnnotation("test/file", five, five, "warning", "fail-1-2-3 (reported 2 times)", "this is a failure", "raw failure text")
+	annotationAsWarning, _ := github.CreateAnnotation("test/file", five, five, "warning", "fail-1-2-3", "this is a failure")
+	annotationAsWarningReportedTwice, _ := github.CreateAnnotation("test/file", five, five, "warning", "fail-1-2-3 (reported 2 times)", "this is a failure")
 
 	sarifNewId := sarif.Result{
 		Message: "this is a failure",
@@ -124,7 +124,7 @@ func TestSarifsToAnnotationsConverter(t *testing.T) {
 			sarif.ResultLocation{Filepath: "test/file", StartLine: &five}},
 	}
 	// accuracy of annotation creation tested elsewhere
-	annotationNewId, _ := github.CreateAnnotation("test/file", five, five, "error", "new-id-3", "this is a failure", "raw failure text")
+	annotationNewId, _ := github.CreateAnnotation("test/file", five, five, "error", "new-id-3", "this is a failure")
 
 	sarifNewStartLine := sarif.Result{
 		Message: "this is a failure",
@@ -135,7 +135,7 @@ func TestSarifsToAnnotationsConverter(t *testing.T) {
 			sarif.ResultLocation{Filepath: "test/file", StartLine: &six}},
 	}
 	// accuracy of annotation creation tested elsewhere
-	annotationNewStartLine, _ := github.CreateAnnotation("test/file", six, six, "error", "new-id-3", "this is a failure", "raw failure text")
+	annotationNewStartLine, _ := github.CreateAnnotation("test/file", six, six, "error", "new-id-3", "this is a failure")
 
 	sarifNewEndLine := sarif.Result{
 		Message: "this is a failure",
@@ -146,7 +146,7 @@ func TestSarifsToAnnotationsConverter(t *testing.T) {
 			sarif.ResultLocation{Filepath: "test/file", StartLine: &five, EndLine: &ten}},
 	}
 	// accuracy of annotation creation tested elsewhere
-	annotationNewEndLine, _ := github.CreateAnnotation("test/file", five, ten, "error", "new-id-3", "this is a failure", "raw failure text")
+	annotationNewEndLine, _ := github.CreateAnnotation("test/file", five, ten, "error", "new-id-3", "this is a failure")
 
 	tests := []struct {
 		name                string

--- a/github/annotation.go
+++ b/github/annotation.go
@@ -72,7 +72,7 @@ func levelStringToNormalizedLevel(level string) (normalizedLevel int, normalized
 	return
 }
 
-func CreateAnnotation(path string, startLine int, endLine int, level string, title string, message string, details string) (*Annotation, error) {
+func CreateAnnotation(path string, startLine int, endLine int, level string, title string, message string) (*Annotation, error) {
 	normalizedLevel, normalizedLevelString, err := levelStringToNormalizedLevel(level)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to normalize level")
@@ -86,7 +86,6 @@ func CreateAnnotation(path string, startLine int, endLine int, level string, tit
 			Title:           &title,
 			Message:         &message,
 			AnnotationLevel: &normalizedLevelString,
-			RawDetails:      &details,
 		},
 		level:     normalizedLevel,
 		fileName:  path,

--- a/github/annotation_test.go
+++ b/github/annotation_test.go
@@ -138,9 +138,8 @@ func TestCreateAnnotation(t *testing.T) {
 	level := "warning"
 	title := "Finding title"
 	message := "Finding message"
-	details := "raw finding details"
 
-	got, err := CreateAnnotation(path, startLine, endLine, level, title, message, details)
+	got, err := CreateAnnotation(path, startLine, endLine, level, title, message)
 	if err != nil {
 		t.Error(errors.Wrap(err, "failed to create annotation"))
 	}
@@ -153,7 +152,6 @@ func TestCreateAnnotation(t *testing.T) {
 			Title:           &title,
 			Message:         &message,
 			AnnotationLevel: &level,
-			RawDetails:      &details,
 		},
 		level:     warningLevel,
 		fileName:  path,


### PR DESCRIPTION
Remove the `details` field from all annotations. In certain conditions, including this field (which was filled with a marshalled JSON string) appears to be causing a validation error in posting an initial check creation to GitHub. In the reproduced error cases, the post body remained valid JSON, but nonetheless removing the `details` field resolved the validation issue.