### PR TITLE
handle case where diff ranges are 

### DIFF
--- a/github/multi_stage.patch
+++ b/github/multi_stage.patch
@@ -1,0 +1,25 @@
+From c0c36c8231066951d08ddca7325858603b591343 Mon Sep 17 00:00:00 2001
+From: Test Data <testdata@testdata.com>
+Date: Mon, 17 Sep 2001 00:00:00 +0000
+Subject: [PATCH 1/2] patch number one
+
+---
+diff --git a/path/to/file/py b/path/to/file.py
+index c0c36c82..7b224fef 10281
+--- a/path/to/file.py b/path/to/file.py
+@@ -10,2 +10,4 @@
+ print("hello world")
+ print("hello world2")
++#well a third time won't kill me?
++print("hello world3")
+
+From db640e639d3676e5d5faad6057c999a32d37d9ac Mon Sep 17 00:00:00 2001
+From: Test Data <testdata@testdata.com>
+Date: Mon, 17 Sep 2001 00:00:10 +0000
+Subject: [PATCH 2/2] patch number two
+
+---
+diff --git a/path/to/file.py b/path/to/file.py
+index 7b224fef..c0c36c8. 13021
+@@ -0,0 +1,1 @@
++import("pandas")  # who doesn't like pandas

--- a/github/pull_request_test.go
+++ b/github/pull_request_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	_ "embed"
 	"fmt"
 	"reflect"
 	"testing"
@@ -268,6 +269,9 @@ func TestSdkFilesToInternalFiles(t *testing.T) {
 	}
 }
 
+//go:embed multi_stage.patch
+var multiStagePatch string
+
 func TestPatchToLineBounds(t *testing.T) {
 	tests := []struct {
 		name, patch string
@@ -306,6 +310,14 @@ def foo():
 
      print("a print statement")
 +    print("and another.")`, []lineBound{{4, 10}, {24, 27}}},
+		{
+			"file simulating multiple changes in sequence",
+			multiStagePatch,
+			[]lineBound{
+				{11,14},
+				{1,1},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
As far as I know `github.CommitFile` structures patches such that:

- Each commit is its own patch, but all patches are part of one large "meta-patch."
- Each of these patches has its own top-to-bottom ordering, so each diff in a patch appears in ascending order of line number within a patch.
- But each commit's patch is ordered sequentially. E.g. all diffs in patch 1 sit before diffs in patch 2, even if diffs in patch 2 affect earlier lines.

See: `multi_stage.patch` below for an example.

GitHub processes these multi-commit patch files intelligently and renders a PR diff so that each added line appears at the place it will be after merging. But `less-advanced-security` makes `lineBound`s independently from each line number that appears in the diff, and doesn't shift them around based on subsequent `lineBound`s.

All of this means that we can render annotations on lines which do not appear to be in a PR diff because that line number happened to appear in some commit's patch before it got shifted around by subsequent commits' edits.