### PR TITLE
Feature: allow to pass the app key through an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ less-advanced-security --help
 
 Run your sarif-producing scan, writing the sarif file to disk.
 
-Then run
+Then run:
 ```sh
 less-advanced-security --app_id=<app_id> --install_id=<installation_id> --key_path=<path_to_key> --sha=<sha_of_target_commit> --repo=<repo_owner>/<repo_name> --pr=<pr_number> --sarif_path=<path_to_sarif_file>
 ```
@@ -73,6 +73,9 @@ For example:
 ```sh
 less-advanced-security --app_id=12345 --install_id=87654321 --key_path=tmp/application_private_key.pem --sha=ee5dabb638b6b874c42bc3c915cf94d4b6b346b6 --repo=eliblock/less-advanced-security --pr=57 --sarif_path=/tmp/scan-results/sarif.json
 ```
+
+The application's private key can also be supplied through the `APP_KEY` environment variable instead of
+the `--key_path` flag.
 
 ### Configuration
 

--- a/github/client.go
+++ b/github/client.go
@@ -10,11 +10,11 @@ import (
 
 type ClientConfiguration struct {
 	AppID, InstallationID int64
-	AppKeyPath            string
+	AppKey                []byte
 }
 
 func createClient(configuration ClientConfiguration) (*github.Client, error) {
-	itr, err := ghinstallation.NewKeyFromFile(http.DefaultTransport, configuration.AppID, configuration.InstallationID, configuration.AppKeyPath)
+	itr, err := ghinstallation.New(http.DefaultTransport, configuration.AppID, configuration.InstallationID, configuration.AppKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to configure GitHub access")
 	}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"less-advanced-security/github"
 	"less-advanced-security/sarif"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -24,7 +25,11 @@ func main() {
 
 	appID := flag.Int("app_id", -1, "app id for your GitHub app")
 	installID := flag.Int("install_id", -1, "install id for your GitHub app installation")
-	appKeyPath := flag.String("key_path", "", "absolute path to your GitHub app's private key")
+	appKeyPath := flag.String(
+		"key_path", "",
+		"absolute path to your GitHub app's private key. "+
+			"The environment variable APP_KEY can also be used instead (the flag takes precedence).",
+	)
 
 	sarifPath := flag.String("sarif_path", "", "absolute path to your sarif file")
 	checkNameOverride := flag.String("check_name", "", "name of the check, defaults to tool name from sarif")
@@ -37,6 +42,20 @@ func main() {
 	if *versionFlag {
 		fmt.Printf("%s\n", version)
 		return
+	}
+
+	var err error
+
+	// Optionally loads the application's private key from the APP_KEY environment variable.
+	// If it's not defined, then it will be blank and we will attempt to load a file instead (if provided).
+	appKey := []byte(os.Getenv("APP_KEY"))
+
+	// Load the GitHub application's private key from path if provided.
+	// This flag takes precedence over the APP_KEY variable.
+	if *appKeyPath != "" {
+		if appKey, err = os.ReadFile(*appKeyPath); err != nil {
+			log.Fatal(errors.Wrap(err, "failed to load the GitHub app's private key"))
+		}
 	}
 
 	parsedRepo := strings.Split(*repo, "/")
@@ -52,7 +71,7 @@ func main() {
 	}
 
 	annotator, err := github.CreatePullRequestAnnotator(
-		github.ClientConfiguration{AppID: int64(*appID), InstallationID: int64(*installID), AppKeyPath: *appKeyPath},
+		github.ClientConfiguration{AppID: int64(*appID), InstallationID: int64(*installID), AppKey: appKey},
 		github.PullRequestConfiguration{Owner: parsedRepo[0], Repo: parsedRepo[1], Number: *prNumber},
 		*sha,
 	)


### PR DESCRIPTION
This adds the possibility to supply the GitHub application's private key through a new environment variable: `APP_KEY`. This is useful in CI/CDs where secrets may not be stored in files, and users may not wish to store them into an intermediary file.

Note: there is no validation whether or not a private key was supplied as there wasn't any check in the original code either. Let me know if you would like me to add a check.