### PR TITLE
handle patches with no offset 🫡

### DIFF
--- a/github/pull_request_test.go
+++ b/github/pull_request_test.go
@@ -282,6 +282,17 @@ func TestPatchToLineBounds(t *testing.T) {
 +4
 `, []lineBound{{1, 4}},
 		},
+		{"new one-line file with no end offset", `
+@@ -0,0 +1 @@
++1
+`, []lineBound{{1, 1}},
+		},
+		{"removed file", `
+@@ -1,224 +1 @@
+-1
+`, []lineBound{{1, 1}},
+		},
+
 		{"file with a change in the middle", `
 @@ -4,4 +4,5 @@ something_arbitrary_here
 


### PR DESCRIPTION
Sometimes, e.g., when a one line file is added or when a file is entirely removed, the patch's new line numbers contain only a single number (e.g., `@@ -0,0 +1 @@` or `@@ -1,224 +1 @@`).

Previously this would panic. Instead, handle it gracefully!